### PR TITLE
Add patch to fix issues building with cmake

### DIFF
--- a/sdformat3.rb
+++ b/sdformat3.rb
@@ -24,7 +24,12 @@ class Sdformat3 < Formula
 
   conflicts_with "sdformat", :because => "Differing version of the same formula"
   conflicts_with "sdformat4", :because => "Differing version of the same formula"
-
+  patch do
+    # Fix for cmake 3.9
+    # As per https://github.com/osrf/homebrew-simulation/issues/263
+    url "https://bitbucket.org/osrf/sdformat/commits/3e1d3f3bd0387b548d347b423a2bea39a7872003/raw/"
+    sha256 "b7fda735c24bf152c44213368575c1addc9ab91d4125611157f79bef32a36250"
+  end
   def install
     ENV.m64
 


### PR DESCRIPTION
Implements the patch suggested in this thread
https://github.com/osrf/homebrew-simulation/issues/263

I was able to build sdfromat3 with cmake 3.10.1 with this patch applied.